### PR TITLE
bug fix

### DIFF
--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -220,12 +220,15 @@
           (output-file  (or (plist-get args :output-file)      "")))
       ;; Export file content by ox-hexo.el
       (with-temp-buffer
-        ;; Insert input-file contents
-        (insert-file-contents file)
+	(cd (file-name-directory file))
+	;; Insert input-file contents
+	(insert-file-contents file)
         ;; Insert common options
         (hexo-renderer-org-insert-options hexo-renderer-org-common-block)
         ;; Export the org-mode file to HTML (default)
         (hexo-renderer-org-exporter)
+	;; replace out bibliography header if exist
+	(replace-string "<h1 class='org-ref-bib-h1'>Bibliography</h1>" "")
         ;; Write contents to output-file
         (write-region (point-min) (point-max) output-file)
         ;; bye-bye tmp buffer

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -82,7 +82,7 @@ function render_html(html, config) {
     });
 
     //reslove(get_content($));
-    reslove($.html());
+    reslove($.html({decodeEntities:false}));
   });
 }
 


### PR DESCRIPTION
fix bug of section name with utf-8 character been escaped in sidebar toc

e.g

![image](https://user-images.githubusercontent.com/1796810/80801009-a164ea00-8bdd-11ea-9179-03283d5bc717.png)
